### PR TITLE
chatspace自動更新機能の実装

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -2,7 +2,7 @@ $(function(){
   function buildHTML(message){
     if ( message.image ) {
       var html =
-        `<div class="message">
+        `<div class="message" data-message-id=${message.id}>
           <div class="upper-message">
             <div class="upper-message__user-name">
               ${message.user_name}
@@ -21,7 +21,7 @@ $(function(){
         return html;
       } else {
         var html =
-         `<div class="message">
+         `<div class="message" data-message-id=${message.id}>
             <div class="upper-message">
               <div class="upper-message__user-name">
                 ${message.user_name}
@@ -65,4 +65,30 @@ $('#new_message').on('submit', function(e){
       $('form')[0].reset();
     })
   })
+
+  var reloadMessages = function() {
+    var last_message_id = $('.message:last').data("message-id");
+    $.ajax({
+      url: "api/messages",
+      type: 'get',
+      dataType: 'json',
+      data: {id: last_message_id}
+    })
+    .done(function(messages) {
+      if (messages.length !== 0) {
+        var insertHTML = '';
+        $.each(messages, function(i, message) {
+          insertHTML += buildHTML(message)
+        });
+        $('.messages').append(insertHTML);
+        $('.messages').animate({ scrollTop: $('.messages')[0].scrollHeight});
+      }
+    })
+    .fail(function() {
+      alert('error');
+    });
+  };
+  if (document.location.href.match(/\/groups\/\d+\/messages/)) {
+    setInterval(reloadMessages, 7000);
+  }
 });

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,0 +1,7 @@
+json.array! @messages do |message|
+  json.content message.content
+  json.image message.image.url
+  json.created_at message.created_at.strftime("%Y年%m月%d日 %H時%M分")
+  json.user_name message.user.name
+  json.id message.id
+end

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,4 +1,5 @@
-json.user_name @message.user.name
+json.content    @message.content
+json.image      @message.image.url
 json.created_at @message.created_at.strftime("%Y年%m月%d日 %H時%M分")
-json.content @message.content
-json.image @message.image_url
+json.user_name @message.user.name
+json.id @message.id


### PR DESCRIPTION
# Why
###  現状のままでは、自分が行った操作に対して非同期通信により必要な部分のチャットを更新できる。しかし、グループを作った時にいる他のメンバーに対してはやり取りが、リロードをしてからとなってしまいやり取りに１テンポ入る。そこで自動更新機能があれば、他メンバーからのやり取りもリアルタイムでリロードせずにみることが可能となる。

# What
### 自動更新機能を実装するために、WebAPIという仕組みを利用した。（TwitterのAPIを利用すればTwitterアプリを使うことなく呟きの情報が取得できる。）
setInterval()関数を使うことで一定時間ごとに処理を行うもので、今回は７秒ごとにメッセージが更新されるように設定した。